### PR TITLE
move create session fingerprint to an async handler

### DIFF
--- a/dist/base.d.ts
+++ b/dist/base.d.ts
@@ -10,6 +10,7 @@ export declare abstract class Base {
     constructor(config: Config);
     protected getFP(): any;
     protected fingerprint(): Promise<any>;
+    protected fullFingerprint(): Promise<any>;
     protected getUrlParam(paramName: string): string | null;
     protected getAllUrlParams(): {
         key: string;
@@ -17,4 +18,5 @@ export declare abstract class Base {
     }[];
     protected getRequest<T>(endpoint: string, options?: any): Promise<T>;
     protected postRequest<T>(endpoint: string, options?: any): Promise<T>;
+    protected sendEvent<T>(params?: any): Promise<T>;
 }

--- a/dist/base.d.ts
+++ b/dist/base.d.ts
@@ -18,5 +18,5 @@ export declare abstract class Base {
     }[];
     protected getRequest<T>(endpoint: string, options?: any): Promise<T>;
     protected postRequest<T>(endpoint: string, options?: any): Promise<T>;
-    protected sendEvent<T>(params?: any): Promise<T>;
+    protected onSessionCreated<T>(params?: any): Promise<T>;
 }

--- a/dist/base.js
+++ b/dist/base.js
@@ -68,7 +68,7 @@ class Base {
                 this.baseUrl = 'https://ua-api-dev.helika.io';
                 break;
         }
-        this.sendEvent({
+        this.onSessionCreated({
             projectType: projectType
         });
     }
@@ -157,7 +157,7 @@ class Base {
                 .catch(reject);
         });
     }
-    sendEvent(params) {
+    onSessionCreated(params) {
         return __awaiter(this, void 0, void 0, function* () {
             let fpData = yield this.fullFingerprint();
             //send event to initiate session

--- a/dist/base.js
+++ b/dist/base.js
@@ -43,15 +43,19 @@ class Base {
     constructor(config) {
         this.apiKey = config.apiKey;
         this.sessionID = (0, uuid_1.v4)();
+        var projectType = "UA";
         switch (config.baseUrlOption) {
             case index_1.BaseURLOptions.EVENTS_LOCAL:
                 this.baseUrl = 'http://localhost:8181/v1';
+                projectType = "Events";
                 break;
             case index_1.BaseURLOptions.EVENTS_MAINNET:
                 this.baseUrl = 'https://api.helika.io/v1';
+                projectType = "Events";
                 break;
             case index_1.BaseURLOptions.EVENTS_TESTNET:
                 this.baseUrl = 'https://api-stage.helika.io/v1';
+                projectType = "Events";
                 break;
             case index_1.BaseURLOptions.UA_LOCAL:
                 this.baseUrl = 'http://localhost:3000';
@@ -64,21 +68,9 @@ class Base {
                 this.baseUrl = 'https://ua-api-dev.helika.io';
                 break;
         }
-        //send event to initiate session
-        var initevent = {
-            created_at: new Date().toISOString(),
-            game_id: 'HELIKA_SDK',
-            event_type: 'SESSION_CREATED',
-            event: {
-                message: 'Session created',
-                sdk_type: 'Event'
-            }
-        };
-        let params = {
-            id: this.sessionID,
-            events: [initevent]
-        };
-        this.postRequest(`/game/game-event`, params);
+        this.sendEvent({
+            projectType: projectType
+        });
     }
     getFP() {
         return new Promise((resolve, reject) => {
@@ -99,6 +91,15 @@ class Base {
                 fingerprint_id: fingerprintData === null || fingerprintData === void 0 ? void 0 : fingerprintData.visitorId,
                 request_id: fingerprintData === null || fingerprintData === void 0 ? void 0 : fingerprintData.requestId
             };
+        });
+    }
+    fullFingerprint() {
+        return __awaiter(this, void 0, void 0, function* () {
+            let func = yield this.getFP();
+            let loaded = yield func.load();
+            return yield loaded.get({
+                extendedResult: true
+            });
         });
     }
     getUrlParam(paramName) {
@@ -154,6 +155,28 @@ class Base {
                 resolve(resp.data);
             })
                 .catch(reject);
+        });
+    }
+    sendEvent(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            let fpData = yield this.fullFingerprint();
+            //send event to initiate session
+            var initevent = {
+                created_at: new Date().toISOString(),
+                game_id: 'HELIKA_SDK',
+                event_type: 'SESSION_CREATED',
+                event: {
+                    message: 'Session created',
+                    sdk_type: 'Event',
+                    project_type: params.projectType,
+                    fp_data: fpData
+                }
+            };
+            let event_params = {
+                id: this.sessionID,
+                events: [initevent]
+            };
+            return this.postRequest(`/game/game-event`, event_params);
         });
     }
 }

--- a/dist/base.js
+++ b/dist/base.js
@@ -43,19 +43,19 @@ class Base {
     constructor(config) {
         this.apiKey = config.apiKey;
         this.sessionID = (0, uuid_1.v4)();
-        var projectType = "UA";
+        var sdk_type = "UA";
         switch (config.baseUrlOption) {
             case index_1.BaseURLOptions.EVENTS_LOCAL:
                 this.baseUrl = 'http://localhost:8181/v1';
-                projectType = "Events";
+                sdk_type = "Events";
                 break;
             case index_1.BaseURLOptions.EVENTS_MAINNET:
                 this.baseUrl = 'https://api.helika.io/v1';
-                projectType = "Events";
+                sdk_type = "Events";
                 break;
             case index_1.BaseURLOptions.EVENTS_TESTNET:
                 this.baseUrl = 'https://api-stage.helika.io/v1';
-                projectType = "Events";
+                sdk_type = "Events";
                 break;
             case index_1.BaseURLOptions.UA_LOCAL:
                 this.baseUrl = 'http://localhost:3000';
@@ -69,7 +69,7 @@ class Base {
                 break;
         }
         this.onSessionCreated({
-            projectType: projectType
+            sdk_type: sdk_type
         });
     }
     getFP() {
@@ -167,8 +167,7 @@ class Base {
                 event_type: 'SESSION_CREATED',
                 event: {
                     message: 'Session created',
-                    sdk_type: 'Event',
-                    project_type: params.projectType,
+                    sdk_type: params.sdk_type,
                     fp_data: fpData
                 }
             };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helika-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.m.js",

--- a/src/base.ts
+++ b/src/base.ts
@@ -41,7 +41,7 @@ export abstract class Base {
           this.baseUrl = 'https://ua-api-dev.helika.io';
           break;
     }
-    this.sendEvent({
+    this.onSessionCreated({
       projectType: projectType
     });
 
@@ -138,7 +138,7 @@ export abstract class Base {
     });
   }
 
-  protected async sendEvent<T>(params?: any): Promise<T> {
+  protected async onSessionCreated<T>(params?: any): Promise<T> {
 
     let fpData = await this.fullFingerprint();
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -16,19 +16,19 @@ export abstract class Base {
     this.apiKey = config.apiKey;
     this.sessionID = v4();
 
-    var projectType = "UA";
+    var sdk_type = "UA";
     switch (config.baseUrlOption) {
       case BaseURLOptions.EVENTS_LOCAL:
           this.baseUrl = 'http://localhost:8181/v1';
-          projectType = "Events";
+          sdk_type = "Events";
           break;
       case BaseURLOptions.EVENTS_MAINNET:
           this.baseUrl = 'https://api.helika.io/v1';
-          projectType = "Events";
+          sdk_type = "Events";
           break;
       case BaseURLOptions.EVENTS_TESTNET:
           this.baseUrl = 'https://api-stage.helika.io/v1';
-          projectType = "Events";
+          sdk_type = "Events";
           break;
       case BaseURLOptions.UA_LOCAL:
           this.baseUrl = 'http://localhost:3000';
@@ -42,7 +42,7 @@ export abstract class Base {
           break;
     }
     this.onSessionCreated({
-      projectType: projectType
+      sdk_type: sdk_type
     });
 
   }
@@ -149,8 +149,7 @@ export abstract class Base {
       event_type: 'SESSION_CREATED',
       event: {
         message: 'Session created',
-        sdk_type: 'Event',
-        project_type: params.projectType,
+        sdk_type: params.sdk_type,
         fp_data: fpData
       }
     };


### PR DESCRIPTION
In this PR:

- move create session fingerprint to an async handler
- include full fingerprint data in create session event (regular events only have fingerprint id and session id)